### PR TITLE
Added codesandbox to examples in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
       - restore_cache:
           keys:
             # Restore cached node_modules
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v11-dependencies-
+            - v12-dependencies-
 
       - run:
           name: Add CI global modules
@@ -43,7 +43,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v11-dependencies-{{ checksum "yarn.lock" }}
+          key: v12-dependencies-{{ checksum "yarn.lock" }}
   validate:
     docker:
       - image: circleci/node:10.16.3-browsers
@@ -53,7 +53,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
 
       - run:
           # PR's from forks cannot use the dependency cache for performance reasons
@@ -72,7 +72,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
 
       - run:
           # PR's from forks cannot use the dependency cache for performance reasons
@@ -96,7 +96,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
 
       # PR's from forks cannot use the dependency cache for performance reasons
       - run:
@@ -117,7 +117,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
 
       # PR's from forks cannot use the dependency cache for performance reasons
       - run:
@@ -142,7 +142,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v11-dependencies-{{ checksum "yarn.lock" }}
+            - v12-dependencies-{{ checksum "yarn.lock" }}
 
       # PR's from forks cannot use the dependency cache for performance reasons
       - run:

--- a/docs/about/examples.md
+++ b/docs/about/examples.md
@@ -21,5 +21,6 @@ We have created some basic examples on `codesandbox` for you to play with direct
 - [Simple horizontal list](https://codesandbox.io/s/mmrp44okvj)
 - [Using with function components](https://codesandbox.io/s/zqwz5n5p9x)
 - [Simple DnD between two lists](https://codesandbox.io/s/ql08j35j3q) - _Community made_
+- [Simple DnD between a dynamic number of lists (with function components) and ability to delete items](https://codesandbox.io/s/-w5szl) - _Community made_
 
 [← Back to documentation](/README.md#documentation-)

--- a/docs/patterns/tables.md
+++ b/docs/patterns/tables.md
@@ -26,6 +26,8 @@ The only thing you need to do is set `display: table` on a `<Draggable />` row w
 
 [See example code here](https://react-beautiful-dnd.netlify.com/?selectedKind=Tables&selectedStory=with%20fixed%20width%20columns&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
 
+Some users have experienced issues using the `table-layout` and `display: table` approach. Specifically, that approach of fixed layouts doesn't keep the styling once an element is being dragged. An alternative is to not set `table-layout` or `display: table` when `<Draggable />` is dragging, but rather just set the `width` of each `<td>` permanently. This avoids the need to use any event responders. E.g. in the `<Draggable />`, set each `<td>` to `width: 100px` with inline styling or css. This approach can be found in the [Code Sandbox here](https://codesandbox.io/s/vertical-list-s9rx5?fontsize=14&hidenavigation=1&theme=dark)
+
 ### Strategy 2: dimension locking
 
 This strategy will work with columns that have automatic column widths based on content. It will also work with fixed layouts. **It is a more robust strategy than the first, but it is also less performant.**

--- a/docs/patterns/tables.md
+++ b/docs/patterns/tables.md
@@ -20,7 +20,7 @@ There are two strategies you can use when reordering tables.
 
 ### Strategy 1: fixed layouts
 
-In order to use this strategy the widths of your columns need to be fixed - that is, they will not change depending on what content is placed in the cells. This can be achieve with either a `table-layout: fixed` or `table-layout: auto` as long as you manually set the width of the cells (eg `50%`).
+In order to use this strategy the widths of your columns need to be fixed - that is, they will not change depending on what content is placed in the cells. This can be achieved with either a `table-layout: fixed` or `table-layout: auto` as long as you manually set the width of the cells (eg `50%`).
 
 The only thing you need to do is set `display: table` on a `<Draggable />` row while it is dragging.
 

--- a/src/view/use-sensor-marshal/use-sensor-marshal.js
+++ b/src/view/use-sensor-marshal/use-sensor-marshal.js
@@ -457,7 +457,7 @@ export default function useSensorMarshal({
         return;
       }
 
-      lockAPI.release();
+      lockAPI.tryAbandon();
 
       if (store.getState().phase !== 'IDLE') {
         store.dispatch(flush());

--- a/src/view/use-sensor-marshal/use-sensor-marshal.js
+++ b/src/view/use-sensor-marshal/use-sensor-marshal.js
@@ -30,6 +30,7 @@ import {
   drop as dropAction,
   lift as liftAction,
   type LiftArgs as LiftActionArgs,
+  flush,
 } from '../../state/action-creators';
 import type {
   Registry,
@@ -450,7 +451,20 @@ export default function useSensorMarshal({
     [registry.draggable],
   );
 
-  const tryReleaseLock = useCallback(lockAPI.tryAbandon, [lockAPI]);
+  const tryReleaseLock = useCallback(
+    function tryReleaseLock() {
+      if (!lockAPI.isClaimed()) {
+        return;
+      }
+
+      lockAPI.release();
+
+      if (store.getState().phase !== 'IDLE') {
+        store.dispatch(flush());
+      }
+    },
+    [lockAPI, store],
+  );
   const isLockClaimed = useCallback(lockAPI.isClaimed, [lockAPI]);
 
   const api: SensorAPI = useMemo(

--- a/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
@@ -1,0 +1,31 @@
+// @flow
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { SensorAPI, Sensor } from '../../../../../src/types';
+import { forEachSensor, type Control, simpleLift } from '../../util/controls';
+import { isDragging } from '../../util/helpers';
+import App from '../../util/app';
+import { invariant } from '../../../../../src/invariant';
+
+forEachSensor((control: Control) => {
+  it('should cleanup a drag if a lock is forceably released mid drag', () => {
+    let api: SensorAPI;
+    const sensor: Sensor = (value: SensorAPI) => {
+      api = value;
+    };
+
+    const { getByText } = render(<App sensors={[sensor]} />);
+    const handle: HTMLElement = getByText('item: 0');
+    invariant(api);
+
+    simpleLift(control, handle);
+
+    expect(isDragging(handle)).toBe(true);
+    expect(api.isLockClaimed()).toBe(true);
+
+    api.tryReleaseLock();
+
+    expect(isDragging(handle)).toBe(false);
+    expect(api.isLockClaimed()).toBe(false);
+  });
+});

--- a/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/lock-released-mid-drag.spec.js
@@ -20,14 +20,18 @@ forEachSensor((control: Control) => {
 
     simpleLift(control, handle);
 
-    expect(isDragging(handle)).toBe(true);
     expect(api.isLockClaimed()).toBe(true);
+    expect(isDragging(handle)).toBe(true);
 
     api.tryReleaseLock();
 
-    expect(isDragging(handle)).toBe(false);
     expect(api.isLockClaimed()).toBe(false);
-  });
+    expect(isDragging(handle)).toBe(false);
 
-  it('should allow dragging after a released lock', () => {});
+    // allowing reclaiming after
+    simpleLift(control, handle);
+
+    expect(api.isLockClaimed()).toBe(true);
+    expect(isDragging(handle)).toBe(true);
+  });
 });

--- a/test/unit/integration/drag-handle/shared-behaviours/lock-released-pre-drag.spec.js
+++ b/test/unit/integration/drag-handle/shared-behaviours/lock-released-pre-drag.spec.js
@@ -8,6 +8,11 @@ import App from '../../util/app';
 import { invariant } from '../../../../../src/invariant';
 
 forEachSensor((control: Control) => {
+  // keyboard has no pre lift
+  if (control.name === 'keyboard') {
+    return;
+  }
+
   it('should cleanup a drag if a lock is forceably released mid drag', () => {
     let api: SensorAPI;
     const sensor: Sensor = (value: SensorAPI) => {
@@ -18,16 +23,20 @@ forEachSensor((control: Control) => {
     const handle: HTMLElement = getByText('item: 0');
     invariant(api);
 
-    simpleLift(control, handle);
+    control.preLift(handle);
 
-    expect(isDragging(handle)).toBe(true);
+    // lock is claimed but not dragging yet
     expect(api.isLockClaimed()).toBe(true);
+    expect(isDragging(handle)).toBe(false);
 
     api.tryReleaseLock();
 
     expect(isDragging(handle)).toBe(false);
     expect(api.isLockClaimed()).toBe(false);
-  });
 
-  it('should allow dragging after a released lock', () => {});
+    // a lift after a released lock can get the lock all good
+    simpleLift(control, handle);
+    expect(api.isLockClaimed()).toBe(true);
+    expect(isDragging(handle)).toBe(true);
+  });
 });


### PR DESCRIPTION
Hi! I'm a novice at contributing to open source, so I apologize if I'm not doing this the right way, but I wanted to share this example with the community. I basically combined the "Simple DnD between two lists" example with the "Using with function components" example, and then added the ability to add a droppable area and add/delete an item into a new droppable area. It's not much, but I think it shows some of the awesome modularity and power of react-beautiful-dnd.

Happy to remove this PR and add the suggestion elsewhere if you let me know the best way to proceed. Or just ignore this and I'll continue on my merry way!

Thanks for the amazing library!! It's exactly what I was looking for.